### PR TITLE
DCP-381: Add latest state macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# dbt-dcp-utilities
+This DBT package contains general purpose macros.
 
-dbt packages for BESTSELLER tech
+## Table of contents
+
+* [How to use](#howto-use)
+* [Kafka](#kafka)
+  * [create_latest_view_on_kafka_tables](#create_latest_view_on_kafka_tables)
+  * [get_kafka_table_latest_state](#get_kafka_table_latest_state)
+
+## How to use
+To use this package, put the following in the `packages.yml` file in your DBT project
+```
+packages:
+  - git: https://github.com/BESTSELLER/dbt-dcp-utilities
+    revision: 0.1.0
+```
+When you have done that, execute `dbt deps` in order to download the dependencies.
+This package uses v1.3.0 of dbt-utils - if you run into dependency conflicts you can probably solve this by using the newest version of dbt-utils.
+
+## Kafka
+
+### create_latest_view_on_kafka_tables
+Dynamically creates latest views for all Kafka-ingested tables in a given schema.
+Each view selects the latest record per Kafka key based on the highest offset.
+This macro is useful for building staging views that represent the most recent state
+of each entity in a Kafka topic ingestion table.
+
+To create these views automatically on each run/build, you can invoke this macro with
+the `on_run_start` hook in dbt_project.yml.
+
+Parameters:
+  - `domain`: The domain (e.g., 'DCPA').
+  - `env`: The environment to use (e.g., 'PROD', 'DEV', 'TEST').
+  - `source_schema`: Schema where raw Kafka tables live.
+  - `dest_schema`: Schema where views should be created.
+  - `view_prefix`: Prefix to add to each view name.
+
+###  get_kafka_table_latest_state
+Calculates the latest state of a single Kafka table. The latest state is defined as
+the highest offset for every key.
+
+Parameters:
+  - `input_table`: The table to calculate the latest state for.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This DBT package contains general purpose macros.
 
+⚠️ IMPORTANT NOTE: This is a public repository, do not put any sensitive information here !!!
+
 ## Table of contents
 
 * [How to use](#howto-use)

--- a/macros/create_latest_view_on_kafka_tables.sql
+++ b/macros/create_latest_view_on_kafka_tables.sql
@@ -1,0 +1,45 @@
+{% macro create_latest_view_on_kafka_tables(
+    domain,
+    env='DEV',
+    source_schema='INGEST_KAFKA',
+    dest_schema=none,
+    tbl_prefix='STG__')
+%}
+    {#"""
+        Description:
+            Dynamically creates latest views for all Kafka-ingested tables in a given schema.
+            Each view selects the latest record per Kafka key based on the highest offset.
+            This macro is useful for building staging views that represent the most recent state
+            of each entity in a Kafka topic ingestion table.
+
+            To create these views automatically on each run/build, you can invoke this macro with
+            the on_run_start hook in dbt_project.yml.
+
+        Parameters:
+            - domain (str): The domain (e.g., 'DCPA').
+            - env (str, default='DEV'): The environment to use (e.g., 'PROD', 'DEV', 'TEST').
+            - source_schema (str, default='INGEST_KAFKA'): Schema where raw Kafka tables live.
+            - dest_schema (str, default=none): Schema where views should be created.
+            - view_prefix (str, default='STG__'): Prefix to add to each view name.
+    """#}
+    {% set source_database = domain ~ '_RAW' ~ ('' if env == 'PROD' or env == '' else '_' ~ env) ~ '_DB'%}
+    {% set tbls = dbt_utils.get_relations_by_prefix(schema=source_schema, prefix='', database=source_database) %}
+    {% set schema_name = generate_schema_name(dest_schema) %}
+    {{ log("Generating latest view for all tables in: " ~ source_database ~ '.' ~ source_schema ) }}
+    {{ log("Creating latest views in the schema: " ~ schema_name) }}
+
+    CREATE SCHEMA IF NOT EXISTS {{ schema_name }};
+    {% for tbl in tbls %}
+        CREATE OR REPLACE VIEW {{ schema_name }}.{{ view_prefix }}{{ tbl.identifier }}_latest
+            COMMENT='Latest state of {{ tbl }}. This view provides the latest registered value for each Kafka key.\n\nThis view was created automatically by the "create_latest_view" macro which was executed automatically using the on-run-start hook.'
+        AS
+            SELECT * EXCLUDE row_num
+            FROM (
+                SELECT 
+                    *,
+                    ROW_NUMBER() OVER (PARTITION BY RECORD_METADATA:key ORDER BY RECORD_METADATA:offset DESC) AS row_num
+                FROM {{ tbl }}
+            )
+            WHERE row_num = 1;
+    {% endfor %}
+{% endmacro %}

--- a/macros/kafka/create_latest_view_on_all_kafka_tables.sql
+++ b/macros/kafka/create_latest_view_on_all_kafka_tables.sql
@@ -5,23 +5,6 @@
     dest_schema=none,
     tbl_prefix='STG__')
 %}
-    {#"""
-        Description:
-            Dynamically creates latest views for all Kafka-ingested tables in a given schema.
-            Each view selects the latest record per Kafka key based on the highest offset.
-            This macro is useful for building staging views that represent the most recent state
-            of each entity in a Kafka topic ingestion table.
-
-            To create these views automatically on each run/build, you can invoke this macro with
-            the on_run_start hook in dbt_project.yml.
-
-        Parameters:
-            - domain (str): The domain (e.g., 'DCPA').
-            - env (str, default='DEV'): The environment to use (e.g., 'PROD', 'DEV', 'TEST').
-            - source_schema (str, default='INGEST_KAFKA'): Schema where raw Kafka tables live.
-            - dest_schema (str, default=none): Schema where views should be created.
-            - view_prefix (str, default='STG__'): Prefix to add to each view name.
-    """#}
     {% set source_database = domain ~ '_RAW' ~ ('' if env == 'PROD' or env == '' else '_' ~ env) ~ '_DB'%}
     {% set tbls = dbt_utils.get_relations_by_prefix(schema=source_schema, prefix='', database=source_database) %}
     {% set schema_name = generate_schema_name(dest_schema) %}

--- a/macros/kafka/create_latest_view_on_all_kafka_tables.sql
+++ b/macros/kafka/create_latest_view_on_all_kafka_tables.sql
@@ -16,13 +16,6 @@
         CREATE OR REPLACE VIEW {{ schema_name }}.{{ view_prefix }}{{ tbl.identifier }}_latest
             COMMENT='Latest state of {{ tbl }}. This view provides the latest registered value for each Kafka key.\n\nThis view was created automatically by the "create_latest_view" macro which was executed automatically using the on-run-start hook.'
         AS
-            SELECT * EXCLUDE row_num
-            FROM (
-                SELECT 
-                    *,
-                    ROW_NUMBER() OVER (PARTITION BY RECORD_METADATA:key ORDER BY RECORD_METADATA:offset DESC) AS row_num
-                FROM {{ tbl }}
-            )
-            WHERE row_num = 1;
+            {{ get_kafka_table_latest_state(tbl) }}
     {% endfor %}
 {% endmacro %}

--- a/macros/kafka/get_kafka_table_latest_state.sql
+++ b/macros/kafka/get_kafka_table_latest_state.sql
@@ -1,0 +1,12 @@
+{% macro get_kafka_table_latest_state(
+    input_table
+)
+%}
+    SELECT * EXCLUDE row_num FROM (
+        SELECT 
+            *,
+            ROW_NUMBER() OVER (PARTITION BY RECORD_METADATA:key ORDER BY RECORD_METADATA:offset DESC) AS row_num
+        FROM {{ input_table }}
+    )
+    WHERE row_num = 1;
+{% endmacro %}


### PR DESCRIPTION
Two macros are added. One for getting the latest state (defined by the highest offset per key) and one for automatically creating "latest state" views for all tables in any given schema. This macro can invoked using the `on_run_start` DBT hook in order to automatically create these views when running DBT.