### PR TITLE
Macro to remove CI schemas 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This DBT package contains general purpose macros.
 * [Kafka](#kafka)
   * [create_latest_view_on_kafka_tables](#create_latest_view_on_kafka_tables)
   * [get_kafka_table_latest_state](#get_kafka_table_latest_state)
+* [DBT-core Github Actions](#DBT-coreGithubActions)
+  * [drop_ci_schema](#drop_ci_schema)
 
 ## How to use
 To use this package, put the following in the `packages.yml` file in your DBT project
@@ -40,6 +42,16 @@ Parameters:
 ###  get_kafka_table_latest_state
 Calculates the latest state of a single Kafka table. The latest state is defined as
 the highest offset for every key.
+
+## DBT-core Github Actions
+
+### drop_ci_schema
+Drop a schema based on the schema and database parameters. This macro is used strictly in the CI jobs and is hard-coded to only work for schemas prefixed with DBT_CI_PR_ and databases suffixed with _TEST_DB. 
+
+Parameters:
+  - `schema`: Name of the schema to be dropped recursively.
+  - `database`: Name of the database containing the schema (defaults to target.database).
+
 
 Parameters:
   - `input_table`: The table to calculate the latest state for.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Parameters:
 Calculates the latest state of a single Kafka table. The latest state is defined as
 the highest offset for every key.
 
+Parameters:
+  - `input_table`: The table to calculate the latest state for.
+
 ## DBT-core Github Actions
 
 ### drop_ci_schema
@@ -51,7 +54,3 @@ Drop a schema based on the schema and database parameters. This macro is used st
 Parameters:
   - `schema`: Name of the schema to be dropped recursively.
   - `database`: Name of the database containing the schema (defaults to target.database).
-
-
-Parameters:
-  - `input_table`: The table to calculate the latest state for.

--- a/macros/dbt/drop_ci_schema.sql
+++ b/macros/dbt/drop_ci_schema.sql
@@ -1,0 +1,26 @@
+-- macros/drop_ci_schema.sql
+{% macro drop_ci_schema(schema, database=None) %}
+  {# require a schema #}
+  {% if not schema %}
+    {{ exceptions.raise_compiler_error("schema is required") }}
+  {% endif %}
+
+  {# pick database: explicit arg or default to target.database #}
+  {% set db = (database if database else target.database) %}
+
+  {# enforce CI naming rules #}
+  {% if not schema.startswith('DBT_CI_PR_') %}
+    {{ exceptions.raise_compiler_error("schema must start with DBT_CI_PR_") }}
+  {% endif %}
+  {% if not db.endswith('_TEST_DB') %}
+    {{ exceptions.raise_compiler_error("database must end with _TEST_DB") }}
+  {% endif %}
+
+  {# Snowflake-friendly DROP #}
+  {% set sql -%}
+    drop schema if exists {{ adapter.quote(db) }}.{{ adapter.quote(schema) }} cascade
+  {%- endset %}
+
+  {{ log(sql, info=true) }}
+  {% do run_query(sql) %}
+{% endmacro %}


### PR DESCRIPTION
This story is made as part of the story on resuable CI workflows for dbt core: https://bestjira.atlassian.net/browse/DCP-549

As part of the workflow I would like to drop CI schemas after use to avoid clutter. I have added some guard rails to make the macro usable for CI schemas strictly. Let me know if you think is not necessary as it make the macro only useful for CI flows.

