### PR TITLE
Updated macro to loop through all CI tables

### DIFF
--- a/macros/dbt/drop_ci_schema.sql
+++ b/macros/dbt/drop_ci_schema.sql
@@ -16,11 +16,23 @@
     {{ exceptions.raise_compiler_error("database must end with _TEST_DB") }}
   {% endif %}
 
-  {# Snowflake-friendly DROP #}
-  {% set sql -%}
-    drop schema if exists {{ adapter.quote(db) }}.{{ adapter.quote(schema) }} cascade
+  {# find all schemas in db that start with the schema name #}
+  {% set find_sql -%}
+    select schema_name
+    from {{ adapter.quote(db) }}.information_schema.schemata
+    where schema_name ilike '{{ schema }}%'
   {%- endset %}
 
-  {{ log(sql, info=true) }}
-  {% do run_query(sql) %}
+  {% set res = run_query(find_sql) %}
+
+  {# loop and drop each matched schema #}
+  {% for row in res.rows %}
+    {% set sname = row[0] %}
+    {% set drop_sql -%}
+      drop schema if exists {{ adapter.quote(db) }}.{{ adapter.quote(sname) }} cascade
+    {%- endset %}
+    {{ log(drop_sql, info=true) }}
+    {% do run_query(drop_sql) %}
+  {% endfor %}
+
 {% endmacro %}


### PR DESCRIPTION
# Motivation for change
We found that only the "base" table was deleted at CI clean up i.e. "DBT_CI_PR_44" and not "DBT_CI_PR_44_kafka"

# Description of change
* Make loop over all files with input schema as prefix
