### PR TITLE
DCP-768 - feat: Consolidate dna-public-dbt-macros and dbt-dcp-utilities into one

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
-*                @BESTSELLER/digital-connectivity-platform
-/macros/cleanup/ @BESTSELLER/dna-consumer-360-team
+*               @BESTSELLER/digital-connectivity-platform
+macros/cleanup/ @BESTSELLER/dna-consumer-360-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
-*       @BESTSELLER/digital-connectivity-platform
+*                @BESTSELLER/digital-connectivity-platform
+/macros/cleanup/ @BESTSELLER/dna-consumer-360-team

--- a/macros/_macros.yml
+++ b/macros/_macros.yml
@@ -1,0 +1,18 @@
+version: 2 
+
+macros: 
+  - name: generate_schema_name
+    description: >
+      This macro will overwrite the dbt-core built-in macro for generating schema names. 
+      It wil instead generate environment-based schema names. When there is a custom schema name, 
+      it will create the schema with the custom name in production, 
+      and <default_name>_<custom_name> for all other environments. 
+      When there is no custom schema name, it will have the default name as schema name. 
+      Requirement is that the dbt project has set an environment variable `DBT_ENV_NAME` which is set to 
+      `prod` for the production enviornment.
+      dbtLabs' docs and thoughts about the macro can be found [here](https://docs.getdbt.com/docs/build/custom-schemas#changing-the-way-dbt-generates-a-schema-name).
+    arguments: 
+      - name: custom_schema_name
+        description: The configured value of schema in the specified node, or none if a value is not supplied.
+      - name: node
+        description: The node that is currently being processed by dbt.

--- a/macros/_macros.yml
+++ b/macros/_macros.yml
@@ -4,12 +4,12 @@ macros:
   - name: generate_schema_name
     description: >
       This macro will overwrite the dbt-core built-in macro for generating schema names. 
-      It wil instead generate environment-based schema names. When there is a custom schema name, 
+      It will instead generate environment-based schema names. When there is a custom schema name, 
       it will create the schema with the custom name in production, 
       and <default_name>_<custom_name> for all other environments. 
       When there is no custom schema name, it will have the default name as schema name. 
       Requirement is that the dbt project has set an environment variable `DBT_ENV_NAME` which is set to 
-      `prod` for the production enviornment.
+      `prod` for the production environment.
       dbtLabs' docs and thoughts about the macro can be found [here](https://docs.getdbt.com/docs/build/custom-schemas#changing-the-way-dbt-generates-a-schema-name).
     arguments: 
       - name: custom_schema_name

--- a/macros/cleanup/_cleanup_macros.yml
+++ b/macros/cleanup/_cleanup_macros.yml
@@ -1,0 +1,52 @@
+version: 2 
+
+macros: 
+  - name: drop_deprecated_tables_and_views
+    description: >
+      This macro will drop all tables and views from the database that are not referenced by dbt. 
+      Objects in the target database belonging to schemas containing dbt sources will remain untouched by this operation.
+      It can be run via __dbt run-operation drop_deprecated_tables_and_views --args '{dry_run: False}'__ . 
+      When run in dry_mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
+    arguments: 
+      - name: dry_run
+        description: Boolean. Set to false if you really want to drop the tables and views not controled by dbt.
+
+  - name: drop_empty_schemas
+    description: >
+      This macro checks all current database schemas and drops those that do not 
+      contain any views or tables. It can be run via __dbt run-operation drop_empty_schemas --args '{dry_run: False}'__ .
+      To be run after the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+      When run in dry_mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
+    arguments: 
+      - name: dry_run
+        description: Boolean. Set to false if you really want to drop the empty schemas. 
+
+  - name: get_all_tables_and_views
+    description: >
+      This macro returns a list of tables and views from the target databases as well as the schema name.
+      Snowflake's default metadata schema INFORMATION_SCHEMA is excluded.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_dbt_nodes
+    description: >
+      This macro parses the dbt model graph and returns all tables and views.
+      Only models materialized as view, table or incremental and seeds are considered. 
+      Incremental models and seeds are treated as tables. 
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_dbt_sources_schemas
+    description: >
+      This macro returns a list of all database.schema names contained within the dbt model graph
+      for all sources, if the source exists in the _target_ database.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_exception_schemas
+    description: >
+      This macro returns a list of all schemas that are supposed to be ignored when either the drop_deprecated_tables_and_views or the drop_empty_schemas macro is run. The list gets compiled from a seed file called 'cleanup_exceptions.csv'. If any objects are defined in that file, then the seed file from the dna-public-dbt-macros repo needs to be disabled in the project's dbt_project.yml file.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+
+  - name: get_exception_tables_views
+    description: >
+      This macro returns a list of all table and view objects (incl schema name) that are supposed to be ignored when the drop_deprecated_tables_and_views macro is run. The list gets compiled from a seed file called 'cleanup_exceptions.csv'. If any objects are defined in that file, then the seed file from the dna-public-dbt-macros repo needs to be disabled in the project's dbt_project.yml file.
+      The macro is used as input for the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
+  

--- a/macros/cleanup/_cleanup_macros.yml
+++ b/macros/cleanup/_cleanup_macros.yml
@@ -6,17 +6,17 @@ macros:
       This macro will drop all tables and views from the database that are not referenced by dbt. 
       Objects in the target database belonging to schemas containing dbt sources will remain untouched by this operation.
       It can be run via __dbt run-operation drop_deprecated_tables_and_views --args '{dry_run: False}'__ . 
-      When run in dry_mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
+      When run in dry_run mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
     arguments: 
       - name: dry_run
-        description: Boolean. Set to false if you really want to drop the tables and views not controled by dbt.
+        description: Boolean. Set to false if you really want to drop the tables and views not controlled by dbt.
 
   - name: drop_empty_schemas
     description: >
       This macro checks all current database schemas and drops those that do not 
       contain any views or tables. It can be run via __dbt run-operation drop_empty_schemas --args '{dry_run: False}'__ .
       To be run after the [drop_deprecated_tables_and_views](/#!/macro/macro.bestseller_dna_cons_dbt.drop_deprecated_tables_and_views) macro.
-      When run in dry_mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
+      When run in dry_run mode, this macro will return an error if there are any tables or views to be dropped, so that an alert can be set up on it.
     arguments: 
       - name: dry_run
         description: Boolean. Set to false if you really want to drop the empty schemas. 

--- a/macros/cleanup/drop_deprecated_tables_and_views.sql
+++ b/macros/cleanup/drop_deprecated_tables_and_views.sql
@@ -1,0 +1,55 @@
+{% macro drop_deprecated_tables_and_views(dry_run=true) %}
+  
+  {# 
+  This macro will drop all tables and views from the database that are not referenced by dbt. 
+  Note: objects belonging to schemas containing dbt sources will remain untouched by this operation.
+  #}
+  
+  {{ log( 'Dropping unknown tables and views. dry_run: ' ~ dry_run , info=true) }}
+  
+  {% set all_tables_and_views = dbt_dcp_utilities.get_all_tables_and_views() %}
+  {% set dbt_tables_and_views = dbt_dcp_utilities.get_dbt_nodes() %}
+  {% set ns = namespace(existsInDbt=false, query='') %}
+  {% set dbt_sources_schemas = dbt_dcp_utilities.get_dbt_sources_schemas() %}
+  {% set excluded_schemas = dbt_dcp_utilities.get_exception_schemas() %}
+  {% set excluded_objects = dbt_dcp_utilities.get_exception_tables_views() %}
+  {% set model_counter = [] %}
+
+  {{ log( 'Starting to drop non-dbt tables and views. dry_run: ' ~ dry_run , info=true) }}
+  {% for relation in all_tables_and_views %}
+    {% if relation.schema not in dbt_sources_schemas and relation.schema not in excluded_schemas %}
+
+      {% set ns.existsInDbt = false %}
+      {% for node in dbt_tables_and_views %}
+        {% if (relation.schema.upper() == node.schema.upper() and relation.name.upper() == node.name.upper()) or ( relation.schema.upper() ~ '.' ~ relation.name.upper() in excluded_objects) %}
+          {% set ns.existsInDbt = true %}
+        {% endif %}
+      {% endfor %}
+
+      {# Only drop objects that do not exist in dbt  #}
+      {% if not ns.existsInDbt %}
+        
+        {% if relation.type == 'view' %}
+          {% set ns.query = 'DROP VIEW IF EXISTS ' + relation.schema + '.' + relation.name %}
+        {% else %}
+          {% set ns.query = 'DROP TABLE IF EXISTS ' + relation.schema + '.' + relation.name %}
+        {% endif %}
+
+        {{ log( ns.query , info=true) }}
+        {% set __ = model_counter.append(1) %}
+
+        {% if not dry_run %}
+          {% do run_query(ns.query) %}
+        {% endif %}
+
+      {% endif %}
+    {% endif %}
+    
+  {% endfor %}
+
+  {# error on this macro during dry-run so we can set up an alert #}
+  {% if model_counter|length > 0 and dry_run %}
+  {{ exceptions.raise_compiler_error("The Cleanup Job has found " ~ model_counter|length ~ " deprecated table(s) or view(s) to be dropped  (Dry-Run).") }}
+  {% endif %}
+
+{% endmacro %}

--- a/macros/cleanup/drop_deprecated_tables_and_views.sql
+++ b/macros/cleanup/drop_deprecated_tables_and_views.sql
@@ -27,7 +27,7 @@
 
   {{ log( 'Starting to drop non-dbt tables and views. dry_run: ' ~ dry_run , info=true) }}
   {% for relation in all_tables_and_views %}
-    {% if relation.schema not in dbt_sources_schemas and relation.schema not in excluded_schemas %}
+    {% if relation.schema.upper() not in dbt_sources_schemas and relation.schema.upper() not in excluded_schemas %}
       {% set relation_full_name = relation.schema.upper() ~ '.' ~ relation.name.upper() %}
       {% set ns.existsInDbt = relation_full_name in dbt_full_names or relation_full_name in excluded_full_names %}
 

--- a/macros/cleanup/drop_deprecated_tables_and_views.sql
+++ b/macros/cleanup/drop_deprecated_tables_and_views.sql
@@ -15,16 +15,21 @@
   {% set excluded_objects = dbt_dcp_utilities.get_exception_tables_views() %}
   {% set model_counter = [] %}
 
+  {# Precompute full names as dictionaries for O(1) lookups #}
+  {% set dbt_full_names = {} %}
+  {% set excluded_full_names = {} %}
+  {% for node in dbt_tables_and_views %}
+    {% do dbt_full_names.update({(node.schema.upper() ~ '.' ~ node.name.upper()): true}) %}
+  {% endfor %}
+  {% for excluded_object in excluded_objects %}
+    {% do excluded_full_names.update({(excluded_object.upper()): true}) %}
+  {% endfor %}
+
   {{ log( 'Starting to drop non-dbt tables and views. dry_run: ' ~ dry_run , info=true) }}
   {% for relation in all_tables_and_views %}
     {% if relation.schema not in dbt_sources_schemas and relation.schema not in excluded_schemas %}
-
-      {% set ns.existsInDbt = false %}
-      {% for node in dbt_tables_and_views %}
-        {% if (relation.schema.upper() == node.schema.upper() and relation.name.upper() == node.name.upper()) or ( relation.schema.upper() ~ '.' ~ relation.name.upper() in excluded_objects) %}
-          {% set ns.existsInDbt = true %}
-        {% endif %}
-      {% endfor %}
+      {% set relation_full_name = relation.schema.upper() ~ '.' ~ relation.name.upper() %}
+      {% set ns.existsInDbt = relation_full_name in dbt_full_names or relation_full_name in excluded_full_names %}
 
       {# Only drop objects that do not exist in dbt  #}
       {% if not ns.existsInDbt %}

--- a/macros/cleanup/drop_empty_schemas.sql
+++ b/macros/cleanup/drop_empty_schemas.sql
@@ -9,7 +9,6 @@
   {% set schema_results = run_query('SHOW SCHEMAS') %}
   {% set all_schemas = schema_results.columns[1].values() %}
   {% set excluded_schemas = get_exception_schemas() %}
-  {% set all_tables_and_views = [] %}
   {% set empty_schema_counter = [] %}
 
   {% for schema in all_schemas %}

--- a/macros/cleanup/drop_empty_schemas.sql
+++ b/macros/cleanup/drop_empty_schemas.sql
@@ -1,0 +1,40 @@
+{% macro drop_empty_schemas(dry_run=true) %}
+  
+  {# 
+  This macro checks all current database schemas and drops those that do not 
+  contain any views or tables 
+  #}
+
+  {{ log( 'drop_empty_schemas: Dropping all schemas from database that contain no table/views' , info=true) }}
+  {% set schema_results = run_query('SHOW SCHEMAS') %}
+  {% set all_schemas = schema_results.columns[1].values() %}
+  {% set excluded_schemas = get_exception_schemas() %}
+  {% set all_tables_and_views = [] %}
+  {% set empty_schema_counter = [] %}
+
+  {% for schema in all_schemas %}
+    
+    {% if schema != "INFORMATION_SCHEMA" and schema not in excluded_schemas%}
+      {% set view_results = run_query('SHOW VIEWS IN ' ~ schema) %}
+      {% set table_results = run_query('SHOW TABLES IN ' ~ schema) %}
+
+      {# Only drop if schema is empty #}
+      {% if view_results|length == 0 and table_results|length == 0 %}
+        {% set query = 'DROP SCHEMA ' + schema %}
+        {{ log( query , info=true) }}
+        {% set __ = empty_schema_counter.append(1) %}
+
+        {% if not dry_run %}
+          {% do run_query(query) %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+
+  {% endfor %}
+
+  {# error on this macro during dry-run so we can set up an alert #}
+  {% if empty_schema_counter|length > 0 and dry_run %}
+  {{ exceptions.raise_compiler_error("The Cleanup Job has found " ~ empty_schema_counter|length ~ " empty schema(s) to be dropped (Dry-Run).") }}
+  {% endif %}
+
+{% endmacro %}

--- a/macros/cleanup/get_all_tables_and_views.sql
+++ b/macros/cleanup/get_all_tables_and_views.sql
@@ -1,0 +1,35 @@
+{% macro get_all_tables_and_views() %}
+
+  {# 
+  This macro returns a list of tables and views from the target databases as well as the schema name
+  Snowflake's default metadata schema INFORMATION_SCHEMA is excluded.
+  #}
+
+  
+  {{ log( 'get_all_tables_and_views: Loading views and tables from database' , info=true) }}
+  {% set schema_results = run_query('SHOW SCHEMAS') %}
+  {% set all_schemas = schema_results.columns[1].values() %}
+  {% set all_tables_and_views = [] %}
+
+  {% for schema in all_schemas %}
+  {% if schema != "INFORMATION_SCHEMA" %}
+    {% set view_results = run_query('SHOW VIEWS IN ' ~ schema) %}
+    {% set views_in_schema = view_results.columns[1].values() %}
+    {% for name in views_in_schema %}
+      {% set view = {'schema': schema, 'name': name, 'type': 'view'} %}
+      {{ log( view , info=true) }}
+      {% do all_tables_and_views.append(view) %}
+    {% endfor %}
+
+    {% set table_results = run_query('SHOW TABLES IN ' ~ schema) %}
+    {% set tables_in_schema = table_results.columns[1].values() %}
+    {% for name in tables_in_schema %}
+      {% set table = {'schema': schema, 'name': name, 'type': 'table'} %}
+      {{ log( table , info=true) }}
+      {% do all_tables_and_views.append(table) %}
+    {% endfor %}
+  {% endif %}
+  {% endfor %}
+
+  {{ return(all_tables_and_views) }}
+{% endmacro %}

--- a/macros/cleanup/get_dbt_nodes.sql
+++ b/macros/cleanup/get_dbt_nodes.sql
@@ -1,0 +1,52 @@
+{% macro get_dbt_nodes() %}
+
+  {# 
+  This macro parses the dbt model graph and returns all tables and views
+
+  Note:
+  Only models materialized as view, table or incremental and seeds are considered. 
+  Incremental models and seeds are treated as tables. 
+  #}
+
+  {{ log( 'get_dbt_nodes: Loading views and tables from dbt graph' , info=true) }}  
+  {% set dbt_tables_and_views = [] %}
+  {% set table_materializations = ["table", "incremental", "seed"] %}
+  {% set all_materializations = ["view", "table", "incremental", "seed", "snapshot"] %} 
+  {% set table_resource_types = ["model", "seed", "snapshot"] %}
+
+
+  {% for node in graph.nodes.values() %}
+    {% if node.resource_type in table_resource_types and node.config.get('materialized', 'none') in all_materializations %}
+            {# use this is you want the full json: {{ log( node , info=true) }} #}
+
+            {# Set the schema to what we define in the generate_schema_macro #}
+            {% set schema_name = generate_schema_name(node.config.get('schema'), node) %}
+
+            {# obtaining version #}
+            {% if node.version is number %}
+                {% set node_version = ['_V', node.version]|join %}
+            {% else %}
+                {% set node_version = '' %}
+            {% endif %}
+
+            {# Set the table/view name as alias instead of node name if alias exists, account for versioning #}
+            {% set node_name = node.config.get('alias') 
+                if node.config.get('alias')  
+                else [node.name, node_version]|join %}
+
+
+            {# Set the node_type type as either table or view. #}
+            {% if node.config.get('materialized', 'table') in table_materializations %}
+                {% set node_type = "table" %}
+            {% else %}
+                {% set node_type = "view" %}
+            {% endif %}
+
+            {% set node = {'schema': schema_name, 'name': node_name, 'type': node_type} %}
+            {{ log( node , info=true) }}
+            {% do dbt_tables_and_views.append(node) %}
+    {% endif %}
+  {% endfor %}
+
+  {{ return(dbt_tables_and_views) }}
+{% endmacro %}

--- a/macros/cleanup/get_dbt_sources_schemas.sql
+++ b/macros/cleanup/get_dbt_sources_schemas.sql
@@ -1,0 +1,20 @@
+{% macro get_dbt_sources_schemas() %}
+  
+  {# 
+  This macro returns a list of all database.schema names contained within the dbt model graph
+  for all sources that exist in the target database.
+  #}
+  
+  {% set dbt_sources_schemas = [] %}
+  {% for node in graph.sources.values() %}
+    {% if node.schema is not none and node.database.upper() == target.database.upper() %}
+      {% if node.schema.upper() not in dbt_sources_schemas %}
+        {% set msg ='Found source schema in target database: ' + node.database + '.' + node.schema %}
+        {{ log( msg , info=true) }}
+        {% do dbt_sources_schemas.append(node.schema.upper()) %}
+      {% endif %}      
+    {% endif %}
+  {% endfor %}
+
+  {{ return(dbt_sources_schemas) }}
+{% endmacro %}

--- a/macros/cleanup/get_exception_schemas.sql
+++ b/macros/cleanup/get_exception_schemas.sql
@@ -1,0 +1,19 @@
+{% macro get_exception_schemas() %}
+  
+  {# 
+  This macro returns a list of all schemas that should get excluded by the cleanup macros by entry in the cleanup_exceptions.csv file.
+  #}
+
+  {% set excluded_schemas = [] %}
+  {% set exclude_schemas = dbt_utils.get_column_values(table=ref('cleanup_exceptions'), column='schema_name', where="object_type='schema'") %}
+  {% if exclude_schemas %}
+  {% for schema in exclude_schemas %}
+    {% set msg ='Found schema in exceptions: ' ~ schema.upper() %}
+    {{ log( msg , info=true) }}
+    {% do excluded_schemas.append(schema.upper()) %}
+  {% endfor %}
+  {% endif %}
+
+  {{ return(excluded_schemas) }}
+
+{% endmacro %}

--- a/macros/cleanup/get_exception_schemas.sql
+++ b/macros/cleanup/get_exception_schemas.sql
@@ -5,7 +5,7 @@
   #}
 
   {% set excluded_schemas = [] %}
-  {% set exclude_schemas = dbt_utils.get_column_values(table=ref('cleanup_exceptions'), column='schema_name', where="object_type='schema'") %}
+  {% set exclude_schemas = dbt_utils.get_column_values(table=ref('cleanup_exceptions'), column='schema_name', where="lower(object_type)='schema'") %}
   {% if exclude_schemas %}
   {% for schema in exclude_schemas %}
     {% set msg ='Found schema in exceptions: ' ~ schema.upper() %}

--- a/macros/cleanup/get_exception_tables_views.sql
+++ b/macros/cleanup/get_exception_tables_views.sql
@@ -1,0 +1,24 @@
+{% macro get_exception_tables_views() %}
+  
+  {# 
+  This macro returns a list of all tables and views that should get excluded by the cleanup macros by entry in the cleanup_exceptions.csv file. It makes no difference if an object is declared as view or table in the exceptions file.
+  #}
+
+{% set excluded_objects = [] %}
+
+{% set sql_query %}
+    select distinct upper(schema_name) || '.' || upper(object_name) as full_name from {{ ref('cleanup_exceptions') }} where lower(object_type) in ('view','table')
+{% endset %}
+{% set exclude_objects = dbt_utils.get_query_results_as_dict(sql_query) %}
+
+{% if exclude_objects %}
+  {% for object in exclude_objects['FULL_NAME'] %}
+    {% set msg ='Found view/table in exceptions: ' ~ object %}
+    {{ log( msg , info=true) }}
+    {% do excluded_objects.append(object) %}
+  {% endfor %}
+{% endif %}
+
+{{ return(excluded_objects) }}
+
+{% endmacro %}

--- a/seeds/cleanup_exceptions.csv
+++ b/seeds/cleanup_exceptions.csv
@@ -1,0 +1,1 @@
+object_type,schema_name,object_name,comment


### PR DESCRIPTION

# Motivation for change
Having two repos might be nice for the repo owners because they don’t have to ask another team when making changes, but it is not nice for the users.

The two repos are [GitHub - BESTSELLER/dna-public-dbt-macros: This is dna public macros repo](https://github.com/BESTSELLER/dna-public-dbt-macros)  and [GitHub - BESTSELLER/dbt-dcp-utilities: This is dbt-dcp-utilities](https://github.com/BESTSELLER/dbt-dcp-utilities) .

As a data engineer, I prefer to refer to a single repo for getting common DBT macros used in BESTSELLER.

# Description of change
* Consolidate dna-public-dbt-macros and dbt-dcp-utilities into one
* All macros have been moved to one repo or the other
* Macros are nicely documented.

DCP-768